### PR TITLE
commit proper bowerrc file to the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ results
 npm-debug.log
 node_modules
 bower_components
-.bowerrc
 .idea/*
 *.iml
 *.sublime-*

--- a/content/themes/codefresh/.bowerrc
+++ b/content/themes/codefresh/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "assets/bower_components"
+}


### PR DESCRIPTION
@Razielt77 This should fix the library issue. The .gitignore file was ignoring the bower config file. After you pull down this code, you will need to run `bower install` from inside `content/themes/codefresh` again. You can delete the earlier `bower_components` folder that was created.